### PR TITLE
mongodb_user: fix checking if the roles of an oplog reader user changed

### DIFF
--- a/database/misc/mongodb_user.py
+++ b/database/misc/mongodb_user.py
@@ -193,6 +193,43 @@ def load_mongocnf():
 
     return creds
 
+
+
+def check_if_roles_changed(uinfo, roles, db_name):
+# The reason for such complicated method is a user which can read the oplog on a replicaset
+# This user must have access to the local DB, but since this DB does not have users
+# and is not synchronized among replica sets, the user must be stored on the admin db
+# {
+#     "_id" : "admin.oplog_reader",
+#     "user" : "oplog_reader",
+#     "db" : "admin",
+#     "roles" : [
+#         {
+#             "role" : "read",
+#             "db" : "local"
+#         }
+#     ]
+# }
+
+    def make_sure_roles_are_a_list_of_dict(roles, db_name):
+        output = list()
+        for role in roles:
+            if isinstance(role, basestring):
+                new_role = { "role": role, "db": db_name }
+                output.append(new_role)
+            else:
+                output.append(role)
+        return output
+
+    roles_as_list_of_dict = make_sure_roles_are_a_list_of_dict(roles, db_name)
+    uinfo_roles = uinfo.get('roles', [])
+
+    if sorted(roles_as_list_of_dict) == sorted(uinfo_roles):
+        return False
+    return True
+
+
+
 # =========================================
 # Module execution.
 #
@@ -265,7 +302,7 @@ def main():
         uinfo = user_find(client, user, db_name)
         if update_password != 'always' and uinfo:
             password = None
-            if list(map((lambda x: x['role']), uinfo.get('roles', []))) == roles:
+            if not check_if_roles_changed(uinfo, roles, db_name):
                 module.exit_json(changed=False, user=user)
 
         try:

--- a/database/misc/mongodb_user.py
+++ b/database/misc/mongodb_user.py
@@ -196,17 +196,18 @@ def load_mongocnf():
 
 
 def check_if_roles_changed(uinfo, roles, db_name):
-# The reason for such complicated method is a user which can read the oplog on a replicaset
-# This user must have access to the local DB, but since this DB does not have users
+# We must be aware of users which can read the oplog on a replicaset
+# Such users must have access to the local DB, but since this DB does not store users credentials
 # and is not synchronized among replica sets, the user must be stored on the admin db
+# Therefore their structure is the following :
 # {
 #     "_id" : "admin.oplog_reader",
 #     "user" : "oplog_reader",
-#     "db" : "admin",
+#     "db" : "admin",                    # <-- admin DB
 #     "roles" : [
 #         {
 #             "role" : "read",
-#             "db" : "local"
+#             "db" : "local"             # <-- local DB
 #         }
 #     ]
 # }


### PR DESCRIPTION
##### Issue Type:


 - Bugfix Pull Request

##### Plugin Name:

mongodb_users.py

##### Ansible Version:

```
ansible 2.0.0.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

##### Summary:

The fix to check if a user has changed does not work with some types of users.
```
# We must be aware of users which can read the oplog on a replicaset
# Such users must have access to the local DB, but since this DB does not store users credentials
# and is not synchronized among replica sets, the user must be stored on the admin db
# Therefore their structure is the following :
# {
#     "_id" : "admin.oplog_reader",
#     "user" : "oplog_reader",
#     "db" : "admin",                    # <-- admin DB
#     "roles" : [
#         {
#             "role" : "read",
#             "db" : "local"             # <-- local DB
#         }
#     ]
# }
```
##### Example output:

It now works as expected, i.e. we run the first time it creates/changes the users and subsequent runs do not cause any changes
